### PR TITLE
Fix API Service Unavailable: Add `six` Module and Update `mongo_server_version`

### DIFF
--- a/infra/modules/cosmos/cosmos.tf
+++ b/infra/modules/cosmos/cosmos.tf
@@ -28,7 +28,7 @@ resource "azurerm_cosmosdb_account" "db" {
   kind                            = "MongoDB"
   enable_automatic_failover       = false
   enable_multiple_write_locations = false
-  mongo_server_version            = "4.0"
+  mongo_server_version            = "4.2"
   tags                            = var.tags
 
   capabilities {

--- a/src/api/requirements.txt
+++ b/src/api/requirements.txt
@@ -8,3 +8,4 @@ azure-identity == 1.21.0
 azure-keyvault-secrets == 4.4.*
 opentelemetry-instrumentation-fastapi == 0.42b0
 azure-monitor-opentelemetry-exporter == 1.0.0b19
+six == 1.17.0


### PR DESCRIPTION
This PR fixes two issues in `todo-python-mongo-terraform`: issue https://github.com/Azure-Samples/todo-python-mongo/issues/7 and issue https://github.com/Azure-Samples/todo-python-mongo-terraform/issues/9.

1. For issue https://github.com/Azure-Samples/todo-python-mongo/issues/7: Added `six==1.17.0` to `src/api/requirements.txt`.
2. For issue #9: Updated the value of `mongo_server_version` to `4.2` in `infra/modules/cosmos/cosmos.tf`.

@rajeshkamal5050, @vhvb1989 and @JeffreyCA for notification.