### PR TITLE
Change database from Azure Cosmos DB to Azure DocumentDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ languages:
 - html
 products:
 - azure
-- azure-cosmos-db
+- azure-documentdb
 - azure-app-service
 - azure-monitor
 - azure-pipelines
 urlFragment: todo-python-mongo-terraform
 name: React Web App with Python API and MongoDB (Terraform) on Azure
-description: A complete ToDo app with Python FastAPI and Azure Cosmos API for MongoDB for storage. Uses Azure Developer CLI (azd) to build, deploy, and monitor
+description: A complete ToDo app with Python FastAPI and Azure DocumentDB (with MongoDB compatibility) for storage. Uses Azure Developer CLI (azd) to build, deploy, and monitor
 ---
 <!-- YAML front-matter schema: https://review.learn.microsoft.com/en-us/help/contribute/samples/process/onboarding?branch=main#supported-metadata-fields-for-readmemd -->
 
@@ -64,7 +64,7 @@ azd up
 This application utilizes the following Azure resources:
 
 - [**Azure App Services**](https://docs.microsoft.com/azure/app-service/) to host the Web frontend and API backend
-- [**Azure Cosmos DB API for MongoDB**](https://docs.microsoft.com/azure/cosmos-db/mongodb/mongodb-introduction) for storage
+- [**Azure DocumentDB (with MongoDB compatibility)**](https://learn.microsoft.com/en-us/azure/documentdb/) for storage
 - [**Azure Monitor**](https://docs.microsoft.com/azure/azure-monitor/) for monitoring and logging
 - [**Azure Key Vault**](https://docs.microsoft.com/azure/key-vault/) for securing secrets
 
@@ -106,7 +106,7 @@ This template creates a [managed identity](https://docs.microsoft.com/azure/acti
 
 ### Key Vault
 
-This template uses [Azure Key Vault](https://docs.microsoft.com/azure/key-vault/general/overview) to securely store your Cosmos DB connection string for the provisioned Cosmos DB account. Key Vault is a cloud service for securely storing and accessing secrets (API keys, passwords, certificates, cryptographic keys) and makes it simple to give other Azure services access to them. As you continue developing your solution, you may add as many secrets to your Key Vault as you require.
+This template uses [Azure Key Vault](https://docs.microsoft.com/azure/key-vault/general/overview) to securely store your DocumentDB connection string for the provisioned DocumentDB account. Key Vault is a cloud service for securely storing and accessing secrets (API keys, passwords, certificates, cryptographic keys) and makes it simple to give other Azure services access to them. As you continue developing your solution, you may add as many secrets to your Key Vault as you require.
 
 ## Reporting Issues and Feedback
 

--- a/infra/modules/cosmos/cosmos.tf
+++ b/infra/modules/cosmos/cosmos.tf
@@ -11,16 +11,16 @@ terraform {
   }
 }
 # ------------------------------------------------------------------------------------------------------
-# Deploy cosmos db account
+# Deploy documentdb account
 # ------------------------------------------------------------------------------------------------------
 resource "azurecaf_name" "db_acc_name" {
   name          = var.resource_token
-  resource_type = "azurerm_cosmosdb_account"
+  resource_type = "azurerm_documentdb_account"
   random_length = 0
   clean_input   = true
 }
 
-resource "azurerm_cosmosdb_account" "db" {
+resource "azurerm_documentdb_account" "db" {
   name                            = azurecaf_name.db_acc_name.result
   location                        = var.location
   resource_group_name             = var.rg_name
@@ -50,19 +50,19 @@ resource "azurerm_cosmosdb_account" "db" {
 }
 
 # ------------------------------------------------------------------------------------------------------
-# Deploy cosmos mongo db and collections
+# Deploy documentdb mongo db and collections
 # ------------------------------------------------------------------------------------------------------
-resource "azurerm_cosmosdb_mongo_database" "mongodb" {
+resource "azurerm_documentdb_mongo_database" "mongodb" {
   name                = "Todo"
-  resource_group_name = azurerm_cosmosdb_account.db.resource_group_name
-  account_name        = azurerm_cosmosdb_account.db.name
+  resource_group_name = azurerm_documentdb_account.db.resource_group_name
+  account_name        = azurerm_documentdb_account.db.name
 }
 
-resource "azurerm_cosmosdb_mongo_collection" "list" {
+resource "azurerm_documentdb_mongo_collection" "list" {
   name                = "TodoList"
-  resource_group_name = azurerm_cosmosdb_account.db.resource_group_name
-  account_name        = azurerm_cosmosdb_account.db.name
-  database_name       = azurerm_cosmosdb_mongo_database.mongodb.name
+  resource_group_name = azurerm_documentdb_account.db.resource_group_name
+  account_name        = azurerm_documentdb_account.db.name
+  database_name       = azurerm_documentdb_mongo_database.mongodb.name
   shard_key           = "_id"
 
 
@@ -71,11 +71,11 @@ resource "azurerm_cosmosdb_mongo_collection" "list" {
   }
 }
 
-resource "azurerm_cosmosdb_mongo_collection" "item" {
+resource "azurerm_documentdb_mongo_collection" "item" {
   name                = "TodoItem"
-  resource_group_name = azurerm_cosmosdb_account.db.resource_group_name
-  account_name        = azurerm_cosmosdb_account.db.name
-  database_name       = azurerm_cosmosdb_mongo_database.mongodb.name
+  resource_group_name = azurerm_documentdb_account.db.resource_group_name
+  account_name        = azurerm_documentdb_account.db.name
+  database_name       = azurerm_documentdb_mongo_database.mongodb.name
   shard_key           = "_id"
 
   index {

--- a/infra/modules/cosmos/cosmos_output.tf
+++ b/infra/modules/cosmos/cosmos_output.tf
@@ -1,8 +1,8 @@
-output "AZURE_COSMOS_CONNECTION_STRING" {
-  value     = azurerm_cosmosdb_account.db.connection_strings[0]
+output "AZURE_DOCUMENTDB_CONNECTION_STRING" {
+  value     = azurerm_documentdb_account.db.connection_strings[0]
   sensitive = true
 }
 
-output "AZURE_COSMOS_DATABASE_NAME" {
-  value = azurerm_cosmosdb_mongo_database.mongodb.name
+output "AZURE_DOCUMENTDB_DATABASE_NAME" {
+  value = azurerm_documentdb_mongo_database.mongodb.name
 }

--- a/infra/output.tf
+++ b/infra/output.tf
@@ -1,9 +1,9 @@
-output "AZURE_COSMOS_CONNECTION_STRING_KEY" {
-  value = local.cosmos_connection_string_key
+output "AZURE_DOCUMENTDB_CONNECTION_STRING_KEY" {
+  value = local.documentdb_connection_string_key
 }
 
-output "AZURE_COSMOS_DATABASE_NAME" {
-  value = module.cosmos.AZURE_COSMOS_DATABASE_NAME
+output "AZURE_DOCUMENTDB_DATABASE_NAME" {
+  value = module.documentdb.AZURE_DOCUMENTDB_DATABASE_NAME
 }
 
 output "AZURE_KEY_VAULT_ENDPOINT" {

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -18,7 +18,7 @@ $ poetry install
 
 ## Running
 
-Before running, set the `AZURE_COSMOS_CONNECTION_STRING` environment variable to the connection-string for mongo/cosmos.
+Before running, set the `AZURE_DOCUMENTDB_CONNECTION_STRING` environment variable to the connection-string for mongo/documentdb.
 
 Run the following common from the root of the api folder to start the app:
 
@@ -30,7 +30,7 @@ There is also a launch profile in VS Code for debugging.
 
 ## Running in Docker
 
-The environment variable AZURE_COSMOS_CONNECTION_STRING must be set and then application runs on TCP 8080:
+The environment variable AZURE_DOCUMENTDB_CONNECTION_STRING must be set and then application runs on TCP 8080:
 
 ```bash
 docker build . -t fastapi-todo
@@ -43,5 +43,5 @@ The tests can be run from the command line, or the launch profile in VS Code
 
 ```bash
 $ pip install -r requirements-test.txt
-$ AZURE_COSMOS_DATABASE_NAME=test_db python -m pytest tests/
+$ AZURE_DOCUMENTDB_DATABASE_NAME=test_db python -m pytest tests/
 ```

--- a/src/api/tests/conftest.py
+++ b/src/api/tests/conftest.py
@@ -29,9 +29,9 @@ def app_client():
 
 @pytest.fixture(scope="session", autouse=True)
 async def initialize_database():
-    settings.AZURE_COSMOS_DATABASE_NAME = TEST_DB_NAME
+    settings.AZURE_DOCUMENTDB_DATABASE_NAME = TEST_DB_NAME
     mongo_client = motor.motor_asyncio.AsyncIOMotorClient(
-        settings.AZURE_COSMOS_CONNECTION_STRING
+        settings.AZURE_DOCUMENTDB_CONNECTION_STRING
     )
     await mongo_client.drop_database(TEST_DB_NAME)
     yield

--- a/src/api/todo/app.py
+++ b/src/api/todo/app.py
@@ -72,9 +72,9 @@ from . import routes  # NOQA
 @app.on_event("startup")
 async def startup_event():
     client = motor.motor_asyncio.AsyncIOMotorClient(
-        settings.AZURE_COSMOS_CONNECTION_STRING
+        settings.AZURE_DOCUMENTDB_CONNECTION_STRING
     )
     await init_beanie(
-        database=client[settings.AZURE_COSMOS_DATABASE_NAME],
+        database=client[settings.AZURE_DOCUMENTDB_DATABASE_NAME],
         document_models=__beanie_models__,
     )

--- a/src/api/todo/models.py
+++ b/src/api/todo/models.py
@@ -26,8 +26,8 @@ class Settings(BaseSettings):
                     keyvault_client.get_secret(secret.name).value,
                 )
 
-    AZURE_COSMOS_CONNECTION_STRING: str = ""
-    AZURE_COSMOS_DATABASE_NAME: str = "Todo"
+    AZURE_DOCUMENTDB_CONNECTION_STRING: str = ""
+    AZURE_DOCUMENTDB_DATABASE_NAME: str = "Todo"
     AZURE_KEY_VAULT_ENDPOINT: Optional[str] = None
     APPLICATIONINSIGHTS_CONNECTION_STRING: Optional[str] = None
     APPLICATIONINSIGHTS_ROLENAME: Optional[str] = "API"


### PR DESCRIPTION
Azure Cosmos DB for MongoDB vCore API got rebranded to Azure DocumentDB (with MongoDB compatibility). Making changes to reflect that.